### PR TITLE
Fix installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It can work with rollup 2.x.x and @rollup/plugin-typescript 6.x.x.
 ## Installation
 
 ```bash
-npm install rollup-plugin-preact-svg -D
+npm install rollup-plugin-preact-svg-lite -D
 ```
 
 ## Usage


### PR DESCRIPTION
Problem: in the Installation section incorrect NPM module name is used. If to copy and run that command – `npm ERR! No versions available for rollup-plugin-preact-svg`

Solution: Use the correct NPM module name in the Installation section